### PR TITLE
开发api 自定义 声音控制，亮度控制条（原有接口保留）

### DIFF
--- a/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/Common/Implements/SJDeviceVolumeAndBrightnessManager.h
+++ b/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/Common/Implements/SJDeviceVolumeAndBrightnessManager.h
@@ -10,9 +10,36 @@
 #import "SJDeviceVolumeAndBrightnessManagerDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - SJDeviceOutputPromptView
+@protocol SJDeviceOutputPromptViewDataSource <NSObject>
+
+/// 普通状态
+@property (nonatomic, strong, nullable) UIImage *image;
+/// 其实状态
+@property (nonatomic, strong, nullable) UIImage *startImage;
+
+@property (nonatomic, assign) float progress;
+@property (nonatomic, strong, nullable) UIColor *traceColor;
+@property (nonatomic, strong, nullable) UIColor *trackColor;
+@end
+
+@protocol SJDeviceOutputPromptView <NSObject>
+@property (nonatomic, strong) id<SJDeviceOutputPromptViewDataSource> dataSource;
+
+- (void)refreshData;
+@end
+
+
+#pragma mark -
+
 @interface SJDeviceVolumeAndBrightnessManager : NSObject<SJDeviceVolumeAndBrightnessManager>
 + (instancetype)shared;
 
+@property (nonatomic, strong, nullable) id<SJDeviceOutputPromptView> brightnessView;
+@property (nonatomic, strong, nullable) id<SJDeviceOutputPromptView> volumeView;
+
+/// 以下属性 优先于 brightnessView，volumeView中的dataSource的配置
 @property (nonatomic, strong, null_resettable) UIColor *traceColor;
 @property (nonatomic, strong, null_resettable) UIColor *trackColor;
 


### PR DESCRIPTION
1. 提出了 声音控制与亮度控制 View的协议
2. 将他们的数据源协议公开；
3. 为数据源新增了属性，以方便支持 初始状态（静音、亮度为0）
4. manager内部默认view的设置，有一些调整，可能跟你的设计会有一点差异，个人感觉还是比较整洁一些；共同学习共同指正。

暂时 还没有写demo的使用，因为我的项目是swift，到时候看搞个示例、