### PR TITLE
fixbug: 避免每初始化一个控制器就新建 SJFullscreenModeWindow

### DIFF
--- a/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/Common/Implements/SJRotationManager.m
+++ b/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/Common/Implements/SJRotationManager.m
@@ -303,7 +303,18 @@ static NSNotificationName const SJRotationManagerTransitioningValueDidChangeNoti
 }
 
 - (void)_setupWindow {
-    self->_window = [SJFullscreenModeWindow new];
+    //整个app 都使用一个SJFullscreenModeWindow
+    NSArray * allwindows = [UIApplication sharedApplication].windows;
+    BOOL hasSJFullscreenModeWindow = NO;
+    for (SJFullscreenModeWindow * subWindow in allwindows) {
+        if ([subWindow isKindOfClass:[SJFullscreenModeWindow class]]) {
+            hasSJFullscreenModeWindow = YES;
+            self->_window = subWindow;
+        }
+    }
+    if (!hasSJFullscreenModeWindow) {
+        self->_window = [SJFullscreenModeWindow new];
+    }
     self->_window.fullscreenModeViewController.delegate = self;
     self->_window.rootViewController.sj_delegate = self;
     self->_window.frame = UIScreen.mainScreen.bounds;


### PR DESCRIPTION
解决 新进一个控制器就新建一个 SJFullscreenModeWindow 的问题，避免多次push 页面之后点击全屏 再回归正常屏幕，页面不可点击