### PR TITLE
Fix: 增加播放时自动设置AVAudioSession配置

### DIFF
--- a/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/SJBaseVideoPlayer.h
+++ b/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/SJBaseVideoPlayer.h
@@ -60,6 +60,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @interface SJBaseVideoPlayer (SJAVAudioSessionExtended)
+///
+/// 每次执行play的时候是否自动设置 AVAudioSession
+///
+///         default value is YES
+///
+@property (nonatomic) BOOL autoSetAudioSessionWhenPlay;
+
 - (void)setCategory:(AVAudioSessionCategory)category withOptions:(AVAudioSessionCategoryOptions)options;
 - (void)setActiveOptions:(AVAudioSessionSetActiveOptions)options;
 @end

--- a/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/SJBaseVideoPlayer.m
+++ b/Example/Pods/SJBaseVideoPlayer/SJBaseVideoPlayer/SJBaseVideoPlayer.m
@@ -87,6 +87,10 @@ typedef struct _SJPlayerControlInfo {
     } controlLayer;
     
     struct {
+        BOOL autoSetAudioSessionWhenPlay;
+    } audioSessionControl;
+    
+    struct {
         BOOL isAppeared;
         BOOL hiddenFloatSmallViewWhenPlaybackFinished;
     } floatSmallViewControl;
@@ -196,6 +200,7 @@ typedef struct _SJPlayerControlInfo {
     _controlInfo->playbackControl.resumePlaybackWhenPlayerHasFinishedSeeking = YES;
     _controlInfo->floatSmallViewControl.hiddenFloatSmallViewWhenPlaybackFinished = YES;
     _controlInfo->gestureControl.rateWhenLongPressGestureTriggered = 2.0;
+    _controlInfo->audioSessionControl.autoSetAudioSessionWhenPlay = YES;
     _controlInfo->pan.factor = 667;
     _mCategory = AVAudioSessionCategoryPlayback;
     _mSetActiveOptions = AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation;
@@ -623,6 +628,14 @@ typedef struct _SJPlayerControlInfo {
 @end
 
 @implementation SJBaseVideoPlayer (SJAVAudioSessionExtended)
+- (void)setAutoSetAudioSessionWhenPlay:(BOOL)autoSetAudioSessionWhenPlay {
+    _controlInfo->audioSessionControl.autoSetAudioSessionWhenPlay = autoSetAudioSessionWhenPlay;
+}
+
+- (BOOL)autoSetAudioSessionWhenPlay {
+    return _controlInfo->audioSessionControl.autoSetAudioSessionWhenPlay;
+}
+
 - (void)setCategory:(AVAudioSessionCategory)category withOptions:(AVAudioSessionCategoryOptions)options {
     _mCategory = category;
     _mCategoryOptions = options;
@@ -970,16 +983,18 @@ typedef struct _SJPlayerControlInfo {
         return;
     }
     
-    NSError *error = nil;
-    if ( ![AVAudioSession.sharedInstance setCategory:_mCategory withOptions:_mCategoryOptions error:&error] ) {
+    if (_controlInfo->audioSessionControl.autoSetAudioSessionWhenPlay) {
+        NSError *error = nil;
+        if ( ![AVAudioSession.sharedInstance setCategory:_mCategory withOptions:_mCategoryOptions error:&error] ) {
 #ifdef DEBUG
-        NSLog(@"%@", error);
+            NSLog(@"%@", error);
 #endif
-    }
-    if ( ![AVAudioSession.sharedInstance setActive:YES withOptions:_mSetActiveOptions error:&error] ) {
+        }
+        if ( ![AVAudioSession.sharedInstance setActive:YES withOptions:_mSetActiveOptions error:&error] ) {
 #ifdef DEBUG
-        NSLog(@"%@", error);
+            NSLog(@"%@", error);
 #endif
+        }
     }
 
     [_playbackController play];


### PR DESCRIPTION
大佬 我们现在 用腾讯SDK做的多人语音房,  语音房有最小化的效果,  在房间最小化的情况下 使用SJBaseVideoPlayer 播放视频,设置为mute=YES 会出现 语音房声音变小或者声音变为听筒,或者无声的情况, 看到代码中播放器在play的时候  有设置 AVAudioSession  我每次调用播放都会重新设置session 就导致了问题出现,我增加了一个配置可以设置是否自动去设置AVAudioSession